### PR TITLE
Update to the travelops pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pattern-vault.init
 vault.init
 super-linter.log
 common/pattern-vault.init
+scratch

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -21,7 +21,7 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.11
+      channel: release-2.12
 
     elasticsearch:
       name: elasticsearch-operator
@@ -34,6 +34,7 @@ clusterGroup:
     kiali:
       name: kiali-ossm
       namespace: openshift-operators
+      channel: stable
     
     servicemesh:
       name: servicemeshoperator


### PR DESCRIPTION
Minor updates to the pattern for #mbp-736

- the default channel for kiali was candidate and i moved it to stable. the candidate channel deployment was causing failures with the operator deployed service account
- updated channel release for acm to 2.12
- ignore directory where i was stashing configs 