### PR TITLE
Upgrade super-linter to v8.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
 

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -2,5 +2,8 @@
     "default": true,
     "MD003": false,
     "MD013": false,
-    "MD033": false
+    "MD033": false,
+    "MD059": false,
+    "MD060": false,
+    "MD034": false
 }

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,16 +2,20 @@ name: Ansible Lint # feel free to pick your own name
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       # Important: This sets up your GITHUB_WORKSPACE environment variable
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Lint Ansible Playbook
-        uses: ansible/ansible-lint-action@v6
+        uses: ansible/ansible-lint@8ba9595a4acd1b906eb75568b34f6ef592cd1528 # v26
         # Let's point it to the path
         with:
-          path: "ansible/"
+          working_directory: "ansible/"

--- a/.github/workflows/jsonschema.yaml
+++ b/.github/workflows/jsonschema.yaml
@@ -3,6 +3,8 @@ name: Verify json schema
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   jsonschema_tests:
     name: Json Schema tests
@@ -13,10 +15,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -26,7 +30,7 @@ jobs:
           pip install check-jsonschema
 
       - name: Install yq
-        uses: chrisdickinson/setup-yq@latest
+        uses: chrisdickinson/setup-yq@fa3192edd79d6eb0e4e12de8dde3a0c26f2b853b # 2025-08-25
         with:
           yq-version: v4.30.7
 

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -3,6 +3,8 @@ name: Super linter
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     # Name the Job
@@ -12,8 +14,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
@@ -21,7 +24,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -40,5 +43,13 @@ jobs:
           VALIDATE_YAML_PRETTIER: false
           # VALIDATE_DOCKERFILE_HADOLINT: false
           # VALIDATE_MARKDOWN: false
-          # VALIDATE_NATURAL_LANGUAGE: false
           # VALIDATE_TEKTON: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_PYINK: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
+          VALIDATE_TRIVY: false
+          VALIDATE_TYPESCRIPT_ES: false

--- a/.github/workflows/update-metadata.yaml
+++ b/.github/workflows/update-metadata.yaml
@@ -10,14 +10,16 @@ on:
       - "pattern-metadata.yaml"
       - ".github/workflows/update-metadata.yml"
 
+permissions: read-all
+
 jobs:
   update-metadata:
-    uses: validatedpatterns/docs/.github/workflows/metadata-docs.yml@main
+    uses: validatedpatterns/docs/.github/workflows/metadata-docs.yml@main # zizmor: ignore[unpinned-uses]
     permissions: # Workflow-level permissions
       contents: read  # Required for "read-all"
       packages: write # Allows writing to packages
       id-token: write # Allows creating OpenID Connect (OIDC) tokens
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     # For testing you can point to a different branch in the docs repository
     # with:
     #  DOCS_BRANCH: "main"


### PR DESCRIPTION
- Pin super-linter to v8.5.0 (SHA 61abc07d)
- Pin all GitHub Actions to SHA references
- Add persist-credentials: false to checkout steps
- Add permissions: read-all to workflow files
- Add dependabot cooldown and grouping configuration
- Disable new v8 linters not applicable to this repo
- Add FILTER_REGEX_EXCLUDE for nested .github directories
- Add zizmor ignore comments for reusable workflow refs
- Update markdownlint config for new rules
- Migrate ansible-lint-action to ansible/ansible-lint
