### PR TITLE
fix: Pin down servicemesh3 operator version

### DIFF
--- a/values-global.yaml
+++ b/values-global.yaml
@@ -6,6 +6,7 @@ global:
     useCSV: false
     syncPolicy: Automatic
     installPlanApproval: Automatic
+    autoApproveManualInstallPlans: true
 
 main:
   clusterGroupName: hub

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -43,6 +43,9 @@ clusterGroup:
   subscriptions:
     servicemesh:
       name: servicemeshoperator3
+      channel: stable-3.2
+      csv: servicemeshoperator3.v3.2.3
+      installPlanApproval: Manual
     servicemesh-console:
       name: kiali-ossm
     distributed-tracing:
@@ -100,6 +103,9 @@ clusterGroup:
       project: servicemesh
       chart: servicemesh
       chartVersion: 0.1.*
+      overrides:
+        - name: servicemesh.version
+          value: v1.24.3
     temposttack:
       name: tempostack
       namespace: tempo


### PR DESCRIPTION
If we do not pin this down, the version skew eventually break the isto.
The istio resource's version, that is created in the servicemesh chart
is tied together with the operator version
